### PR TITLE
emacs: follow symbolic links

### DIFF
--- a/dotfiles/.emacs.d/settings.el
+++ b/dotfiles/.emacs.d/settings.el
@@ -18,6 +18,8 @@
 (setq backup-directory-alist '(("." . "~/.emacs.d/emacssaves")))
 ;; Don't create lock files
 (setq create-lockfiles nil)
+;; Follow symbolic links
+(setq vc-follow-symlinks t)
 
 ;; --- Indentation Settings ---
 ;; Use spaces instead of tabs


### PR DESCRIPTION
The default is to ask, which causes manual answering to each symlinked file when opening the emacs desktop. Instead, follow by default.