### PR TITLE
emacs: enable org-beautify-theme only when windowed

### DIFF
--- a/dotfiles/.emacs.d/init.el
+++ b/dotfiles/.emacs.d/init.el
@@ -158,8 +158,9 @@
   :ensure t
   :bind (("C-x g" . magit-status)))
 
-(use-package org-beautify-theme
-  :ensure t)
+(when (display-graphic-p)
+  (use-package org-beautify-theme
+    :ensure t))
 
 (use-package projectile
   :ensure t

--- a/dotfiles/.emacs.d/settings.el
+++ b/dotfiles/.emacs.d/settings.el
@@ -13,7 +13,8 @@
 ;; Theme customization
 (setq custom-enabled-themes '(manoj-dark))
 (load-theme 'manoj-dark t)
-(load-theme 'org-beautify t)
+(when (display-graphic-p)
+  (load-theme 'org-beautify t))
 
 ;; Org-mode settings
 (setq org-startup-folded "nofold")


### PR DESCRIPTION
Doesn't work when running in non-windowed mode.