### PR TITLE
bash/functions: add notify-when-done command

### DIFF
--- a/dotfiles/.config/bash/25_functions.sh
+++ b/dotfiles/.config/bash/25_functions.sh
@@ -18,6 +18,51 @@ function less_newest()
     find "$1" -maxdepth 1 -type "f" -printf "%T@ %p\n" | sort -n | cut -d' ' -f 2- | tail -n 1 | xargs less
 }
 
+# notify-when-done, sends a OSC 777 notification after a command, if it
+# exceeds NWD_THRESHOLD. Works for single command, wrap multi-command
+# sequences in bash -c
+#
+# Examples:
+# nwd my-command myparam
+# nwd bash -c "my-command | my-other-command"
+nwd() {
+    local threshold=${NWD_THRESHOLD:-60}
+
+    local start end duration exit_code
+    start=$(date +%s)
+
+    # Run the command
+    "$@"
+    exit_code=$?
+
+    end=$(date +%s)
+    local duration=$((end - start))
+
+    if (( duration >= threshold )); then
+	status=$([[ $exit_code -eq 0 ]] && echo "✓" || echo "✗")
+        local title="${status} Command finished"
+        local body="${*:1} ($duration seconds)"
+
+        _send_osc777 "$title" "$body"
+    fi
+
+    return $exit_code
+}
+
+_send_osc777() {
+    local title="$1"
+    local body="$2"
+
+    # Check if we're in tmux
+    if [[ -n "$TMUX" ]]; then
+        # In tmux, wrap with tmux escape sequence
+        printf '\033Ptmux;\033\033]777;notify;%s;%s\007\033'\\ "$title" "$body" > /dev/tty
+    else
+        # Outside tmux, send directly
+        printf '\033]777;notify;%s;%s\007' "$title" "$body" > /dev/tty
+    fi
+}
+
 # De-duplicates the bash history file
 function dedup_history() {
     local histfile="${HISTFILE}"


### PR DESCRIPTION
Adds nwd(), a command that sends an OSC 777 notification when the command given to it runs longer than NWD_THRESHOLD (default 60s). Works with tmux or without, locally or remotely as long as the terminal supports OSC 777.

It would be possible to use trap...DEBUG + PROMPT_COMMAND to have an alternative solution that auto-applies to all commands without a wrapper command but this has performance impact and requires ignore lists etc so opting for the manual solution.