### PR TITLE
bash: set XDG env vars in .profile

### DIFF
--- a/dotfiles/.bashrc
+++ b/dotfiles/.bashrc
@@ -2,12 +2,6 @@
 # see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
 # for examples
 
-# Explicitly set XDG variables
-export XDG_CONFIG_HOME="${HOME}"/.config
-export XDG_CACHE_HOME="${HOME}"/.cache
-export XDG_DATA_HOME="${HOME}"/.local/share
-export XDG_STATE_HOME="${HOME}"/.local/state
-
 # If not running interactively, don't do anything
 case $- in
     *i*) ;;

--- a/dotfiles/.profile
+++ b/dotfiles/.profile
@@ -8,6 +8,12 @@
 # for ssh logins, install and configure the libpam-umask package.
 # umask 022
 
+# Explicitly set XDG variables
+export XDG_CONFIG_HOME="$HOME/.config"
+export XDG_CACHE_HOME="$HOME/.cache"
+export XDG_DATA_HOME="$HOME/.local/share"
+export XDG_STATE_HOME="$HOME/.local/state"
+
 # include user-specific bin directories
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
It's better to set them in .profile than .bashrc so that they will be set also for apps that don't read .bashrc