### PR TITLE
foot: update notification allowing option

### DIFF
--- a/dotfiles/.config/foot/foot.ini
+++ b/dotfiles/.config/foot/foot.ini
@@ -1,6 +1,9 @@
 [main]
 term=xterm-256color
 font=monospace:size=12
-notify-focus-inhibit=false
+
+[desktop-notifications]
+inhibit-when-focused=false
+
 [scrollback]
 lines=10000


### PR DESCRIPTION
The option name for allowing OSC notifications when focused had changed for newer versions and the old one is not supported anymore.