### PR TITLE
scripts: fix to work when .local/bin doesn't exist

### DIFF
--- a/scripts/asdf.sh
+++ b/scripts/asdf.sh
@@ -6,6 +6,13 @@ dir_path=$(dirname -- "${BASH_SOURCE[0]}")
 source "${dir_path}/utils.inc.sh"
 set -euo pipefail
 
+# asdf is installed to ~/.local/bin, which might not be on PATH yet during
+# installation. Add it if needed so that install-tool calls work.
+case ":${PATH}:" in
+    *":${HOME}/.local/bin:"*) ;;
+    *) export PATH="${HOME}/.local/bin:${PATH}" ;;
+esac
+
 function usage() {
     echo "$(basename "${BASH_SOURCE[0]}") [install]                          Installs asdf"
     echo "$(basename "${BASH_SOURCE[0]}") install-tool <name> [<version>]    Installs a specific or the latest version of a tool"

--- a/scripts/emacs.sh
+++ b/scripts/emacs.sh
@@ -88,6 +88,7 @@ function install_from_sources() {
 
     # Copy the built binary to .local/bin
     __log_info "Symlink emacs to ${HOME}/.local/bin"
+    mkdir -p "${bin_dir}"
     rm -f "${bin_dir}"/emacs
     ln -s "${install_dir}"/bin/emacs "${bin_dir}"/emacs
 }

--- a/scripts/tmux.sh
+++ b/scripts/tmux.sh
@@ -122,6 +122,7 @@ function install_from_sources() {
 
     # Copy the built binary to .local/bin
     __log_info "Copying tmux to ${HOME}/.local/bin"
+    mkdir -p "${HOME}"/.local/bin
     if [ -f "${HOME}"/.local/bin/tmux ]; then
         cp -f "${HOME}"/.local/bin/tmux "${HOME}"/.local/bin/tmux.old
     fi

--- a/scripts/utils.inc.sh
+++ b/scripts/utils.inc.sh
@@ -56,6 +56,10 @@ function utils::install_using_snap() {
             return 1
         fi
 
+        if ! run_cmd mkdir -p "${HOME}/.local/bin"; then
+            __log_error "Failed to create directory ${HOME}/.local/bin"
+            return 1
+        fi
         if ! run_cmd ln -sf "/snap/bin/${toolname}" "${HOME}/.local/bin/${toolname}"; then
             __log_error "Failed to create a symbolic link named ${toolname} to /snap/bin/${toolname}"
             return 1
@@ -131,6 +135,10 @@ function utils::download_github_release() {
     full_asset_url="https://github.com${asset_url}"
     __log_info "Downloading asset: ${full_asset_url}"
 
+    if ! run_cmd mkdir -p "${output_dir}"; then
+        __log_error "Failed to create output directory ${output_dir}"
+        return 1
+    fi
     pushd "${output_dir}" > /dev/null
     if ! run_cmd curl -L -O "${full_asset_url}"; then
         __log_error "Failed to download ${full_asset_url}"
@@ -176,6 +184,10 @@ function utils::download_github_tag_tarball() {
 
     full_asset_url="https://github.com${asset_url}"
 
+    if ! run_cmd mkdir -p "${output_dir}"; then
+        __log_error "Failed to create output directory ${output_dir}"
+        return 1
+    fi
     pushd "${output_dir}" > /dev/null
     if ! run_cmd curl -L -O "${full_asset_url}"; then
         __log_error "Failed to download ${full_asset_url}"

--- a/scripts/zoxide.sh
+++ b/scripts/zoxide.sh
@@ -34,6 +34,7 @@ function install_from_github() {
     tar -xzf "${package}"
 
     __log_info "Copy zoxide to ${HOME}/.local/bin"
+    mkdir -p "${bin_dir}"
     cp -f ./zoxide "${bin_dir}"/zoxide
 }
 


### PR DESCRIPTION
The .local/bin directory might not exist when the installation scripts are run. Take that into account and create when needed.