### PR TITLE
scripts: install fzf and bat from gh rather than asdf

### DIFF
--- a/scripts/all-nonui.sh
+++ b/scripts/all-nonui.sh
@@ -10,7 +10,7 @@ run_script basepackages || true
 run_script emacs || true
 run_script tmux || true
 run_script zoxide || true
+run_script bat || true
+run_script fzf || true
 
 run_script asdf || true
-run_script asdf install-tool bat || true
-run_script asdf install-tool fzf || true

--- a/scripts/bat.sh
+++ b/scripts/bat.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Installs bat from github
+#
+# For having access to a recent version of bat
+
+dir_path=$(dirname -- "${BASH_SOURCE[0]}")
+source "${dir_path}/utils.inc.sh"
+set -euo pipefail
+
+function get_current_bat_version() {
+    if [[ -x "$(command -v bat)" ]]; then
+        bat --version | cut -d ' ' -f2
+    fi
+}
+
+function install_from_github() {
+    local -r tmpdir=$(mktemp -d)
+    local -r bin_dir="${HOME}"/.local/bin
+
+    # shellcheck disable=SC2064
+    trap "trap - RETURN; popd > /dev/null; rm -rf ${tmpdir}" RETURN
+
+    run_cmd echo "Temporary directory: $tmpdir"
+    pushd "${tmpdir}" > /dev/null
+
+    if ! package=$(utils::download_github_release sharkdp bat x86_64-unknown-linux-gnu.tar.gz . "$(get_current_bat_version)"); then
+        __log_error "Failed to download bat"
+        return 1
+    elif [[ -z "${package}" ]]; then
+        return 0
+    fi
+
+    tar -xzf "${package}"
+
+    __log_info "Copy bat to ${HOME}/.local/bin"
+    mkdir -p "${bin_dir}"
+    cp -f ./bat-*/bat "${bin_dir}"/bat
+}
+
+function install_bat() {
+    __log_info "Installing/updating bat"
+    __log_info "Bat version before: $(get_current_bat_version)"
+
+    install_from_github && return 0
+}
+
+install_bat

--- a/scripts/fzf.sh
+++ b/scripts/fzf.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Installs fzf from github
+#
+# For having access to a recent version of fzf
+
+dir_path=$(dirname -- "${BASH_SOURCE[0]}")
+source "${dir_path}/utils.inc.sh"
+set -euo pipefail
+
+function get_current_fzf_version() {
+    if [[ -x "$(command -v fzf)" ]]; then
+        fzf --version | cut -d ' ' -f1
+    fi
+}
+
+function install_from_github() {
+    local -r tmpdir=$(mktemp -d)
+    local -r bin_dir="${HOME}"/.local/bin
+
+    # shellcheck disable=SC2064
+    trap "trap - RETURN; popd > /dev/null; rm -rf ${tmpdir}" RETURN
+
+    run_cmd echo "Temporary directory: $tmpdir"
+    pushd "${tmpdir}" > /dev/null
+
+    if ! package=$(utils::download_github_release junegunn fzf linux_amd64.tar.gz . "$(get_current_fzf_version)"); then
+        __log_error "Failed to download fzf"
+        return 1
+    elif [[ -z "${package}" ]]; then
+        return 0
+    fi
+
+    tar -xzf "${package}"
+
+    __log_info "Copy fzf to ${HOME}/.local/bin"
+    mkdir -p "${bin_dir}"
+    cp -f ./fzf "${bin_dir}"/fzf
+}
+
+function install_fzf() {
+    __log_info "Installing/updating fzf"
+    __log_info "Fzf version before: $(get_current_fzf_version)"
+
+    install_from_github && return 0
+}
+
+install_fzf

--- a/scripts/help.sh
+++ b/scripts/help.sh
@@ -10,8 +10,10 @@ Available scripts:
   -s asdf                               Install asdf
   -s asdf install-tool <toolname>       Install <toolname> using asdf
   -s basepackages                       Install base packages
+  -s bat                                Install bat
   -s desktop                            Install regolith and other desktop related software
   -s emacs                              Install emacs
+  -s fzf                                Install fzf
   -s tmux                               Install tmux
   -s zoxide                             Install zoxide
 EOF


### PR DESCRIPTION
Both have ready made binaries in github while asdf required cargo for bat etc.